### PR TITLE
updates to L.Evented.extend({

### DIFF
--- a/src/leaflet-layerconfig.js
+++ b/src/leaflet-layerconfig.js
@@ -52,9 +52,7 @@ Copyright 2014 Norkart AS
         return !!(value && typeof value === "string");
     }
 
-    L.LayerConfig = L.Class.extend({
-
-        includes: L.Mixin.Events,
+ L.LayerConfig = L.Evented.extend({
 
         _map: null,
 


### PR DESCRIPTION
removes the Mixin warning.